### PR TITLE
Extra mouse buttons + renderer fix

### DIFF
--- a/MonoGame.ImGui.Net6/Data/InputData.cs
+++ b/MonoGame.ImGui.Net6/Data/InputData.cs
@@ -43,6 +43,8 @@ public class InputData
         io.MouseDown[0] = mouse.LeftButton == ButtonState.Pressed;
         io.MouseDown[1] = mouse.RightButton == ButtonState.Pressed;
         io.MouseDown[2] = mouse.MiddleButton == ButtonState.Pressed;
+        io.MouseDown[3] = mouse.XButton1 == ButtonState.Pressed;
+        io.MouseDown[4] = mouse.XButton2 == ButtonState.Pressed;
 
         var scrollDelta = mouse.ScrollWheelValue - _scrollWheel;
         io.MouseWheel = scrollDelta > 0 ? 1 : scrollDelta < 0 ? -1 : 0;

--- a/MonoGame.ImGui.Net6/ImGuiRenderer.cs
+++ b/MonoGame.ImGui.Net6/ImGuiRenderer.cs
@@ -140,17 +140,16 @@ public class ImGuiRenderer
 
                 GraphicsDevice.ScissorRectangle = GenerateScissorRect(drawCommand);
                 var effect = UpdateEffect(_textureData.Loaded[drawCommand.TextureId]);
-
+                
                 foreach (var pass in effect.CurrentTechnique.Passes)
                 {
                     pass.Apply();
-                    DrawPrimitives(vertexOffset, indexOffset, commandList, drawCommand);
+                    DrawPrimitives(vertexOffset, indexOffset + (int)(drawCommand.IdxOffset), commandList, drawCommand);
                 }
-
-                indexOffset += (int)drawCommand.ElemCount;
             }
 
             vertexOffset += commandList.VtxBuffer.Size;
+            indexOffset += commandList.IdxBuffer.Size;
         }
     }
 
@@ -172,11 +171,9 @@ public class ImGuiRenderer
 
         if (drawCommand.ElemCount == 0)
             return;
-        
-        GraphicsDevice.DrawIndexedPrimitives(
-            PrimitiveType.TriangleList, vertexOffset, 0,
-            commandList.VtxBuffer.Size, indexOffset, (int)(drawCommand.ElemCount / 3));
 
+        GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, vertexOffset, indexOffset, (int)(drawCommand.ElemCount / 3));
+        
 
 #pragma warning restore CS0618
     }

--- a/MonoGame.ImGui.Net6/ImGuiRenderer.cs
+++ b/MonoGame.ImGui.Net6/ImGuiRenderer.cs
@@ -103,6 +103,7 @@ public class ImGuiRenderer
         GraphicsDevice.RasterizerState = _rasterizerState;
         GraphicsDevice.DepthStencilState = DepthStencilState.DepthRead;
         GraphicsDevice.SamplerStates[0] = SamplerState.PointClamp; //ADD THIS LINE
+        // GraphicsDevice.SamplerStates[0] = SamplerState.LinearClamp; //ADD THIS LINE
 
 
         // Handle cases of screen coordinates != from framebuffer coordinates (e.g. retina displays)
@@ -169,6 +170,9 @@ public class ImGuiRenderer
 
 #pragma warning disable CS0618
 
+        if (drawCommand.ElemCount == 0)
+            return;
+        
         GraphicsDevice.DrawIndexedPrimitives(
             PrimitiveType.TriangleList, vertexOffset, 0,
             commandList.VtxBuffer.Size, indexOffset, (int)(drawCommand.ElemCount / 3));


### PR DESCRIPTION
I wanted support for what Monogame calls XButton1 and XButton2 on the mouse.

Also fixed the GUI renderer in two places:
 - Crash when drawCommand.elementCount is 0 for some reason
 - Addressing the issue described here: https://github.com/ocornut/imgui/issues/4845#issuecomment-1003329113
  (This fixes the rendering of modal dialogs)